### PR TITLE
Fixed: app not compiling after upgrade deps

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -469,9 +469,12 @@ module.exports = function(webpackEnv) {
               test: /\.hbs$/,
               loader: require.resolve('handlebars-loader'),
               options: {
-                helperDirs: [paths.appSrc + '\\panel-templates\\_helpers'],
-                partialDirs: [paths.appSrc + '\\panel-templates\\_partials']
-                // path.join(__dirname, 'templates', '_partials')
+                helperDirs: [
+                  path.join(paths.appSrc, 'panel-templates', '_helpers')
+                ],
+                partialDirs: [
+                  path.join(paths.appSrc, 'panel-templates', '_partials')
+                ]
               }
             },
             // "postcss" loader applies autoprefixer to our CSS.


### PR DESCRIPTION
Evan here. I refreshed `package-lock.json` on our main repo to comply with a new requirement and it broke compiling for me.

It seems to be a platform-specific issue with using `\` instead of `/` in file paths. This fixed it for me, so please verify it works for you and re-publish on npm 🙏